### PR TITLE
Lock trigger and use TSV export with unified scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 This repository contains a Tkinter-based Python utility that communicates with a motor-control device via [pyX2Cscope](https://pypi.org/project/pyx2cscope/). It performs a triggered capture of motor variables and exports scaled data for analysis.
 
-The logger waits for the *OmegaElectrical* variable to reach the requested speed and then records a high‑resolution window using a fixed sample-time factor of **f = 50** (2.5 ms per sample, ≈400 Hz). Captured series can be exported to CSV in real units and optionally plotted when `matplotlib` is installed.
+The logger triggers on the *OmegaElectrical* variable rising past a fixed raw level of 700 and then records a high‑resolution window using a fixed sample-time factor of **f = 50** (2.5 ms per sample, ≈400 Hz). Captured series can be exported to TSV in real units and optionally plotted when `matplotlib` is installed.
 
 ## Included file
 
-- `logger.py` – Tkinter application implementing the triggered motor logger with per‑channel scaling and CSV export.
+- `logger.py` – Tkinter application implementing the triggered motor logger with per‑channel scaling and TSV export.
 
 ## Requirements
 
@@ -26,7 +26,7 @@ The logger waits for the *OmegaElectrical* variable to reach the requested speed
 
 3. Select the compiled ELF file and serial port, then click **Connect**.
 4. Enter a speed request and start a capture. The tool issues a one‑shot **RUN**, waits for the trigger, and automatically **STOPs** after 10 seconds or when stopped manually.
-5. Use **Export…** to save a CSV with scaled values and **Plot** to visualise currents or speed if `matplotlib` is available.
+5. Use **Export…** to save a TSV with scaled values and **Plot** to visualise currents or speed if `matplotlib` is available.
 
 ## License
 


### PR DESCRIPTION
## Summary
- lock trigger defaults to raw 700 with 10% delay
- centralize current and speed scaling values
- export captured data as tab-separated TSV instead of CSV

## Testing
- `python -m py_compile logger.py`


------
https://chatgpt.com/codex/tasks/task_e_68b5720550f0832395d6eaee5b7011dc